### PR TITLE
support -shared and --whole-archive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
         // Check if the argument is "-shared"
         if args[i] == "-shared" {
             // change it to double hyphen
-            args[i] = "--shared";
+            args[i] = "--shared".into();
         } else {
             // Move to the next argument
             i += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
         // Check if the argument is "-shared"
         if args[i] == "-shared" {
             // change it to double hyphen
-            args[i] == "--shared";
+            args[i] = "--shared";
         } else {
             // Move to the next argument
             i += 1;
@@ -197,7 +197,10 @@ impl App {
             lld.arg("--shared");
         }
         for ar in self.lld.whole_archive_link.iter() {
-            lld.arg(&format!("--whole-archive {} --no-whole-archive", ar.display()));
+            lld.arg(&format!(
+                "--whole-archive {} --no-whole-archive",
+                ar.display()
+            ));
         }
         lld
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ struct WasmLdArgs {
     #[clap(short = 'm')]
     target_emulation: Option<String>,
     #[clap(long)]
+    shared: bool,
+    #[clap(long)]
     strip_all: bool,
 
     objects: Vec<PathBuf>,
@@ -70,8 +72,8 @@ fn main() -> Result<()> {
     while i < args.len() {
         // Check if the argument is "-shared"
         if args[i] == "-shared" {
-            // If found, remove it from the vector
-            args.remove(i);
+            // change it to double hyphen
+            args[i] == "--shared";
         } else {
             // Move to the next argument
             i += 1;
@@ -188,6 +190,9 @@ impl App {
         }
         if let Some(arg) = &self.lld.entry {
             lld.arg("--entry").arg(arg);
+        }
+        if self.lld.shared {
+            lld.arg("--shared");
         }
         lld
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,19 @@ fn main() -> Result<()> {
             args.remove(1);
         }
     }
+
+    let mut i = 1;
+    while i < args.len() {
+        // Check if the argument is "-shared"
+        if args[i] == "-shared" {
+            // If found, remove it from the vector
+            args.remove(i);
+        } else {
+            // Move to the next argument
+            i += 1;
+        }
+    }
+
     App::parse_from(args).run()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,11 @@ struct WasmLdArgs {
     strip_all: bool,
     #[clap(long)]
     whole_archive_link: Vec<PathBuf>,
+    // these are options that should not expose to be set by the user
+    #[clap(long)]
+    whole_archive: Vec<PathBuf>,
+    #[clap(long)]
+    no_whole_archive: bool,
 
     objects: Vec<PathBuf>,
 }
@@ -197,10 +202,9 @@ impl App {
             lld.arg("--shared");
         }
         for ar in self.lld.whole_archive_link.iter() {
-            lld.arg(&format!(
-                "--whole-archive {} --no-whole-archive",
-                ar.display()
-            ));
+            // use unexposed parameters, so clap does not complain about not knowing what they are
+            lld.arg("--whole-archive").arg(ar);
+            lld.arg("--no-whole-archive");
         }
         lld
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ impl App {
             lld.arg("--shared");
         }
         for ar in self.lld.whole_archive_link.iter() {
-            lld.arg(&format!("--whole-archive {ar} --no-whole-archive"));
+            lld.arg(&format!("--whole-archive {} --no-whole-archive", ar.display()));
         }
         lld
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ struct WasmLdArgs {
     shared: bool,
     #[clap(long)]
     strip_all: bool,
+    #[clap(long)]
+    whole_archive_link: Vec<PathBuf>,
 
     objects: Vec<PathBuf>,
 }
@@ -193,6 +195,9 @@ impl App {
         }
         if self.lld.shared {
             lld.arg("--shared");
+        }
+        for ar in self.lld.whole_archive_link.iter() {
+            lld.arg(&format!("--whole-archive {ar} --no-whole-archive"));
         }
         lld
     }


### PR DESCRIPTION
This PR basically does 2 things:

- Add `-shared` and `--shared` parameters. Clap doesn't support single-hyphen arguments so we have to wrangle the argument into one it supports.
- Add a new parameter `--whole-archive-link`. The parameter for this will be passed along as `--whole-archive x --no-whole-archive` to `wasm-ld`.